### PR TITLE
All references to the misspelled "sentinal" have been systematically …

### DIFF
--- a/quark_bot/src/bot/answers.rs
+++ b/quark_bot/src/bot/answers.rs
@@ -12,7 +12,7 @@ use teloxide::{Bot, prelude::*, types::Message};
 use super::handler::{
     handle_add_files, handle_chat, handle_help, handle_list_files, handle_login_group,
     handle_login_user, handle_mod, handle_moderation_rules, handle_new_chat, handle_reasoning_chat,
-    handle_sentinal,
+    handle_sentinel,
 };
 use crate::assets::command_image_collector::CommandImageCollector;
 use crate::bot::handler::{handle_aptos_connect, handle_balance, handle_wallet_address};
@@ -146,8 +146,8 @@ pub async fn answers(
                 .await?;
             }
         }
-        Command::Sentinal(param) => {
-            handle_sentinal(bot, msg, param, db).await?;
+        Command::Sentinel(param) => {
+            handle_sentinel(bot, msg, param, db).await?;
         }
         Command::Mod => {
             handle_mod(bot, msg, db).await?;

--- a/quark_bot/src/bot/handler.rs
+++ b/quark_bot/src/bot/handler.rs
@@ -881,16 +881,16 @@ pub async fn handle_message(
     db: Db,
     tree: Tree,
 ) -> AnyResult<()> {
-    // Sentinal: moderate every message in group if sentinal is on
+    // Sentinel: moderate every message in group if sentinel is on
     if !msg.chat.is_private() {
-        let sentinal_tree = db.open_tree("sentinal_state").unwrap();
+        let sentinel_tree = db.open_tree("sentinel_state").unwrap();
         let chat_id = msg.chat.id.0.to_be_bytes();
-        let sentinal_on = sentinal_tree
+        let sentinel_on = sentinel_tree
             .get(chat_id)
             .unwrap()
             .map(|v| v == b"on")
             .unwrap_or(false);
-        if sentinal_on {
+        if sentinel_on {
             // Don't moderate admin or bot messages
             if let Some(user) = &msg.from {
                 if user.is_bot {
@@ -915,7 +915,7 @@ pub async fn handle_message(
             {
                 Ok(result) => {
                     log::info!(
-                        "Sentinal moderation result: {} for message: {} (tokens: {})",
+                        "Sentinel moderation result: {} for message: {} (tokens: {})",
                         result.verdict,
                         message_text,
                         result.total_tokens
@@ -939,7 +939,7 @@ pub async fn handle_message(
                                 );
                             } else {
                                 log::info!(
-                                    "Successfully muted user {} for flagged content (sentinal)",
+                                    "Successfully muted user {} for flagged content (sentinel)",
                                     flagged_user.id
                                 );
                             }
@@ -969,7 +969,7 @@ pub async fn handle_message(
                     }
                 }
                 Err(e) => {
-                    log::error!("Sentinal moderation failed: {}", e);
+                    log::error!("Sentinel moderation failed: {}", e);
                 }
             }
             return Ok(());
@@ -999,8 +999,8 @@ pub async fn handle_message(
     Ok(())
 }
 
-pub async fn handle_sentinal(bot: Bot, msg: Message, param: String, db: Db) -> AnyResult<()> {
-    // Only admins can use /sentinal
+pub async fn handle_sentinel(bot: Bot, msg: Message, param: String, db: Db) -> AnyResult<()> {
+    // Only admins can use /sentinel
     if !msg.chat.is_private() {
         let admins = bot.get_chat_administrators(msg.chat.id).await?;
         let requester_id = msg.from.as_ref().map(|u| u.id);
@@ -1010,7 +1010,7 @@ pub async fn handle_sentinal(bot: Bot, msg: Message, param: String, db: Db) -> A
         if !is_admin {
             bot.send_message(
                 msg.chat.id,
-                "❌ <b>Permission Denied</b>\n\nOnly group administrators can use /sentinal.",
+                "❌ <b>Permission Denied</b>\n\nOnly group administrators can use /sentinel.",
             )
             .parse_mode(ParseMode::Html)
             .await?;
@@ -1018,23 +1018,23 @@ pub async fn handle_sentinal(bot: Bot, msg: Message, param: String, db: Db) -> A
         }
     }
     let param = param.trim().to_lowercase();
-    let sentinal_tree = db.open_tree("sentinal_state").unwrap();
+    let sentinel_tree = db.open_tree("sentinel_state").unwrap();
     let chat_id = msg.chat.id.0.to_be_bytes();
     match param.as_str() {
         "on" => {
-            sentinal_tree.insert(chat_id, b"on").unwrap();
+            sentinel_tree.insert(chat_id, b"on").unwrap();
             bot.send_message(
                 msg.chat.id,
-                "🛡️ <b>Sentinal System</b>\n\n✅ <b>Sentinal is now ON</b>\n\nAll messages will be automatically moderated. /mod command is disabled."
+                "🛡️ <b>Sentinel System</b>\n\n✅ <b>Sentinel is now ON</b>\n\nAll messages will be automatically moderated. /mod command is disabled."
             )
             .parse_mode(ParseMode::Html)
             .await?;
         }
         "off" => {
-            sentinal_tree.insert(chat_id, b"off").unwrap();
+            sentinel_tree.insert(chat_id, b"off").unwrap();
             bot.send_message(
                 msg.chat.id,
-                "🛡️ <b>Sentinal System</b>\n\n⏹️ <b>Sentinal is now OFF</b>\n\nManual moderation via /mod is re-enabled."
+                "🛡️ <b>Sentinel System</b>\n\n⏹️ <b>Sentinel is now OFF</b>\n\nManual moderation via /mod is re-enabled."
             )
             .parse_mode(ParseMode::Html)
             .await?;
@@ -1042,7 +1042,7 @@ pub async fn handle_sentinal(bot: Bot, msg: Message, param: String, db: Db) -> A
         _ => {
             bot.send_message(
                 msg.chat.id,
-                "❌ <b>Invalid Parameter</b>\n\n📝 Usage: <code>/sentinal on</code> or <code>/sentinal off</code>\n\n💡 Please specify either 'on' or 'off' to control the sentinal system."
+                "❌ <b>Invalid Parameter</b>\n\n📝 Usage: <code>/sentinel on</code> or <code>/sentinel off</code>\n\n💡 Please specify either 'on' or 'off' to control the sentinel system."
             )
             .parse_mode(ParseMode::Html)
             .await?;
@@ -1097,19 +1097,19 @@ pub async fn handle_wallet_address(bot: Bot, msg: Message, tree: Tree) -> AnyRes
 }
 
 pub async fn handle_mod(bot: Bot, msg: Message, db: Db) -> AnyResult<()> {
-    // Check if sentinal is on for this chat
+    // Check if sentinel is on for this chat
     if !msg.chat.is_private() {
-        let sentinal_tree = db.open_tree("sentinal_state").unwrap();
+        let sentinel_tree = db.open_tree("sentinel_state").unwrap();
         let chat_id = msg.chat.id.0.to_be_bytes();
-        let sentinal_on = sentinal_tree
+        let sentinel_on = sentinel_tree
             .get(chat_id)
             .unwrap()
             .map(|v| v == b"on")
             .unwrap_or(false);
-        if sentinal_on {
+        if sentinel_on {
             bot.send_message(
                 msg.chat.id,
-                "🛡️ <b>Sentinal Mode Active</b>\n\n/mod is disabled while sentinal is ON. All messages are being automatically moderated."
+                "🛡️ <b>Sentinel Mode Active</b>\n\n/mod is disabled while sentinel is ON. All messages are being automatically moderated."
             )
             .parse_mode(ParseMode::Html)
             .await?;

--- a/quark_bot/src/bot/handler_tree.rs
+++ b/quark_bot/src/bot/handler_tree.rs
@@ -94,7 +94,7 @@ pub fn handler_tree() -> Handler<'static, Result<()>, DpHandlerDescription> {
                                     | Command::ListFiles
                                     | Command::NewChat
                                     | Command::PromptExamples
-                                    | Command::Sentinal(_)
+                                    | Command::Sentinel(_)
                                     | Command::Mod
                                     | Command::ModerationRules
                             )
@@ -124,7 +124,7 @@ pub fn handler_tree() -> Handler<'static, Result<()>, DpHandlerDescription> {
                         .filter(|msg: Message| msg.chat.is_private())
                         .endpoint(handle_message),
                 )
-                // Handle group messages for sentinal auto-moderation
+                // Handle group messages for sentinel auto-moderation
                 .branch(
                     dptree::entry()
                         .filter(|msg: Message| !msg.chat.is_private())

--- a/quark_bot/src/main.rs
+++ b/quark_bot/src/main.rs
@@ -168,7 +168,7 @@ async fn main() {
             "mysettings",
             "View your current model preferences (DM only).",
         ),
-        BotCommand::new("sentinal", "Monitor system status (on/off)."),
+        BotCommand::new("sentinel", "Monitor system status (on/off)."),
         BotCommand::new("mod", "Moderate content (reply to message)."),
         BotCommand::new(
             "moderationrules",

--- a/quark_core/src/helpers/bot_commands.rs
+++ b/quark_core/src/helpers/bot_commands.rs
@@ -34,9 +34,9 @@ pub enum Command {
     SelectModel,
     #[command(description = "View your current model preferences (DM only).")]
     MySettings,
-    // Change Monitor to Sentinal
-    #[command(description = "Monitor system status (on/off).", rename = "sentinal")]
-    Sentinal(String),
+    // Change Monitor to Sentinel
+    #[command(description = "Monitor system status (on/off).", rename = "sentinel")]
+    Sentinel(String),
     #[command(description = "Moderate content (reply to message).")]
     Mod,
     #[command(description = "Display the moderation rules to avoid getting muted.")]


### PR DESCRIPTION
…replaced with the correct spelling "sentinel" while preserving all functionality and maintaining code consistency.